### PR TITLE
Remove rotation offset, always use WorldNEDtoENU

### DIFF
--- a/include/imu_vn_100/imu_vn_100.h
+++ b/include/imu_vn_100/imu_vn_100.h
@@ -117,9 +117,6 @@ class ImuVn100 {
   double imu_rate_double_ = kDefaultImuRate;
   std::string frame_id_;
 
-  std::vector<double> rotation_rpy_body_;
-  tf2::Quaternion rotation_quaternion_body_;
-
   bool enable_mag_ = true;
   bool enable_pres_ = true;
   bool enable_temp_ = true;

--- a/src/imu_vn_100.cpp
+++ b/src/imu_vn_100.cpp
@@ -492,8 +492,8 @@ void ImuVn100::PublishData(const VnDeviceCompositeData& data) {
   }
   if  (tf_ned_to_enu_) {
     imu_msg.orientation = WorldNEDtoENU(imu_msg.orientation);
-    imu_msg.angular_velocity =  BodyFixedNEDtoENU(imu_msg.angular_velocity);
-    imu_msg.linear_acceleration = BodyFixedNEDtoENU(
+    imu_msg.angular_velocity =  WorldNEDtoENU(imu_msg.angular_velocity);
+    imu_msg.linear_acceleration = WorldNEDtoENU(
       imu_msg.linear_acceleration);
   }
   pd_imu_.Publish(imu_msg);

--- a/src/imu_vn_100.cpp
+++ b/src/imu_vn_100.cpp
@@ -129,10 +129,6 @@ void ImuVn100::LoadParameters() {
 
   pnh_.param("tf_ned_to_enu", tf_ned_to_enu_, false);
 
-  pnh_.param("rotation_rpy_body", rotation_rpy_body_, rotation_rpy_body_);
-
-  rotation_quaternion_body_.setRPY(rotation_rpy_body_.at(0), rotation_rpy_body_.at(1), rotation_rpy_body_.at(2));
-
   pnh_.param("imu_compensated", imu_compensated_, false);
 
   pnh_.param("vpe/enable", vpe_enable_, true);
@@ -476,16 +472,6 @@ void ImuVn100::PublishData(const VnDeviceCompositeData& data) {
     RosVector3FromVnVector3(imu_msg.linear_acceleration,
                             data.angularRateUncompensated);
   }
-
-  tf2::Vector3 temp_vec;
-
-  tf2::convert(imu_msg.angular_velocity, temp_vec);
-  temp_vec = tf2::quatRotate(rotation_quaternion_body_, temp_vec);
-  tf2::convert(temp_vec, imu_msg.angular_velocity);
-
-  tf2::convert(imu_msg.linear_acceleration, temp_vec);
-  temp_vec = tf2::quatRotate(rotation_quaternion_body_, temp_vec);
-  tf2::convert(temp_vec, imu_msg.linear_acceleration);
 
   if (binary_output_) {
     RosQuaternionFromVnQuaternion(imu_msg.orientation, data.quaternion);


### PR DESCRIPTION
* Remove the unneeded body rotation offset 
* Use `WorldNEDtoENU` instead of `BodyFixedNEDtoENU` to have everything in the same frame.

See also [rep 145](http://www.ros.org/reps/rep-0145.html) [rep 105](http://www.ros.org/reps/rep-0105.html)

Testing:
- IMU on Blitz is currently not fully fixed, so recommend playing around with that to check if it makes sense in general
- Disable odom in the blitz ekf and activate acceleration of `y` and `z` for the imu
  - Less drift / gravity compensation works